### PR TITLE
connection.cursor() for MySQL doesn't throw DatabaseError if database doesn't exist for me

### DIFF
--- a/test_utils/test_runners/keep_database.py
+++ b/test_utils/test_runners/keep_database.py
@@ -67,7 +67,7 @@ def run_tests(test_labels, verbosity=1, interactive=True, extra_tests=[]):
             if not os.path.exists(settings.DATABASES['default']['NAME']):
                 raise DatabaseError
         cursor = connection.cursor()
-    except DatabaseError, e:
+    except Exception:
         # db does not exist
         # juggling !  create_test_db switches the DATABASE_NAME to the TEST_DATABASE_NAME
         settings.DATABASES['default']['NAME'] = old_name


### PR DESCRIPTION
If the test database doesn't exist, I get the following exception when running `python manage.py quicktest` using MySQL and Django 1.2.4 on Ubuntu 10.04:

```
$ python manage.py quicktest 
Traceback (most recent call last):
  File "manage.py", line 11, in <module>
    execute_manager(settings)
  File "/home/eliot/.virtualenvs/andys_bakery/lib/python2.6/site-packages/django/core/management/__init__.py", line 438, in execute_manager
    utility.execute()
  File "/home/eliot/.virtualenvs/andys_bakery/lib/python2.6/site-packages/django/core/management/__init__.py", line 379, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/home/eliot/.virtualenvs/andys_bakery/lib/python2.6/site-packages/django/core/management/base.py", line 191, in run_from_argv
    self.execute(*args, **options.__dict__)
  File "/home/eliot/.virtualenvs/andys_bakery/lib/python2.6/site-packages/django/core/management/base.py", line 220, in execute
    output = self.handle(*args, **options)
  File "/home/eliot/.virtualenvs/andys_bakery/src/django-test-utils/test_utils/management/commands/quicktest.py", line 30, in handle
    failures = test_runner(test_labels, verbosity=verbosity, interactive=interactive)
  File "/home/eliot/.virtualenvs/andys_bakery/src/django-test-utils/test_utils/test_runners/keep_database.py", line 69, in run_tests
    cursor = connection.cursor()
  File "/home/eliot/.virtualenvs/andys_bakery/lib/python2.6/site-packages/django/db/backends/__init__.py", line 75, in cursor
    cursor = self._cursor()
  File "/home/eliot/.virtualenvs/andys_bakery/lib/python2.6/site-packages/django/db/backends/mysql/base.py", line 297, in _cursor
    self.connection = Database.connect(**kwargs)
  File "/home/eliot/.virtualenvs/andys_bakery/lib/python2.6/site-packages/MySQLdb/__init__.py", line 81, in Connect
    return Connection(*args, **kwargs)
  File "/home/eliot/.virtualenvs/andys_bakery/lib/python2.6/site-packages/MySQLdb/connections.py", line 187, in __init__
    super(Connection, self).__init__(*args, **kwargs2)
_mysql_exceptions.OperationalError: (1049, "Unknown database 'test_andys_bakery'")
```

Versions:

```
$ pip freeze
BeautifulSoup==3.2.0
Django==1.2.4
MySQL-python==1.2.3
distribute==0.6.10
-e git://github.com/ericholscher/django-test-utils.git@1ed00b3a365ebce7205a7f8f1946d2267555cc90#egg=django_test_utils-0.3-py2.6-1.2-support
wsgiref==0.1.2
```

relevant part of settings.py:

```
DATABASES = {
    'default': {
        'ENGINE': 'django.db.backends.mysql', # Add 'postgresql_psycopg2', 'postgresql', 'mysql', 'sqlite3' or 'oracle'.
        'NAME': 'andys_bakery',                      # Or path to database file if using sqlite3.
        'USER': 'ab_user',                      # Not used with sqlite3.
        'PASSWORD': 'ab_pass',                  # Not used with sqlite3.
        'HOST': '',                      # Set to empty string for localhost. Not used with sqlite3.
        'PORT': '',                      # Set to empty string for default. Not used with sqlite3.
    }
}
INSTALLED_APPS = (
    'django.contrib.auth',
    'django.contrib.contenttypes',
    'django.contrib.sessions',
    'django.contrib.sites',
    'django.contrib.messages',
    # Uncomment the next line to enable the admin:
    # 'django.contrib.admin',
    # Uncomment the next line to enable admin documentation:
    # 'django.contrib.admindocs',
    'oven',
    'test_utils',
)
```

bash history:

```
$ mkvirtualenv --no-site-packages --distribute andys_bakery
$ pip install Django==1.2.4
$ pip install mysql-python
$ django-admin.py startproject andys_bakery
$ cd andys_bakery/
$ python manage.py startapp oven
$ edit settings.py 
$ python manage.py syncdb
$ python manage.py test
$ pip install -e git+git://github.com/ericholscher/django-test-utils.git#egg=django-test-utils
$ cd /home/eliot/.virtualenvs/andys_bakery/src/django-test-utils/
$ git checkout -b 1.2-support remotes/origin/1.2-support
$ cd /home/eliot/src/andys_bakery/
$ edit settings.py 
$ python manage.py quicktest 
```
