### PR TITLE
[crawler] Write out request times to a csv if output_dir is specified

### DIFF
--- a/test_utils/crawler/plugins/time_plugin.py
+++ b/test_utils/crawler/plugins/time_plugin.py
@@ -1,5 +1,7 @@
 import time
 import logging
+import csv
+import os
 
 from base import Plugin
 
@@ -9,10 +11,17 @@ class Time(Plugin):
     """
     Follow the time it takes to run requests.
     """
+    csv_writer = None
 
     def __init__(self):
         super(Time, self).__init__()
         self.timed_urls = self.data['timed_urls'] = {}
+        
+    def set_output_dir(self, output_dir=None):
+        super(Time, self).set_output_dir(output_dir)
+
+        if output_dir:
+            self.csv_writer = csv.writer(open(os.path.join(output_dir, 'url_times.csv'), 'w'))
 
     def pre_request(self, sender, **kwargs):
         url = kwargs['url']
@@ -25,6 +34,9 @@ class Time(Plugin):
         total_time = cur - old_time
         self.timed_urls[url] = total_time
         LOG.debug("Time taken: %s", self.timed_urls[url])
+        
+        if self.csv_writer:
+            self.csv_writer.writerow((url, self.timed_urls[url]))
 
     def finish_run(self, sender, **kwargs):
         "Print the longest time it took for pages to load"


### PR DESCRIPTION
It would be nice to have all request times. This is implemented just like the ``query_count`` plugin does this.