### PR TITLE
[crawler] Skip static/media paths as it doesn't makes sense to crawl them

### DIFF
--- a/test_utils/crawler/base.py
+++ b/test_utils/crawler/base.py
@@ -104,6 +104,11 @@ class Crawler(object):
             if parsed_href.scheme and not parsed_href.netloc.startswith("testserver"):
                 LOG.debug("Skipping external link: %s", link)
                 continue
+                
+            if parsed_href.path.startswith(settings.STATIC_URL) or \
+                    parsed_href.path.startswith(settings.MEDIA_URL):
+                LOG.debug("Skipping static/media link: %s", link)
+                continue
 
             if parsed_href.path.startswith('/'):
                 returned_urls.append(link)


### PR DESCRIPTION
This could also be implemented with an option for the management command if people do depend on / like crawling the static files.
