### PR TITLE
Django 1.4 load_template_source import error

### DIFF
--- a/test_utils/templatetags/__init__.py
+++ b/test_utils/templatetags/__init__.py
@@ -1,8 +1,14 @@
 import re
 import os
 from django.conf import settings
-from django.template.loaders.filesystem import load_template_source
 from django import template
+
+try:
+    from django.template.loaders.filesystem import load_template_source
+except ImportError:
+    from django.template.loaders.filesystem import Loader
+    loader = Loader
+    load_template_source = lambda name: loader.load_template_source(name)
 
 from test_utils.testmaker import Testmaker
 


### PR DESCRIPTION
Django dev server started with "testmaker" command raises an import error on Django 1.4. Because of load_template_source function is wrapped by Loader class now.
This is a small fix for that issue
