### PR TITLE
Fix minor doc typo

### DIFF
--- a/docs/source/testmaker.rst
+++ b/docs/source/testmaker.rst
@@ -125,7 +125,7 @@ currently json, yaml, or xml.
 --addrport
 ----------
 
-This allows you to pass in the normal address and post options for
+This allows you to pass in the normal address and port options for
 runserver.
 
 


### PR DESCRIPTION
Changed "This allows you to pass in the normal address and post options" to "This allows you to pass in the normal address and port options" 

Closes #32 
