### PR TITLE
Added json Standard Module to Support Django 1.7+

### DIFF
--- a/test_utils/testmaker/serializers/json_serializer.py
+++ b/test_utils/testmaker/serializers/json_serializer.py
@@ -1,5 +1,9 @@
 import base
-from django.utils import simplejson as json
+try:
+    from django.utils import simplejson as json
+except ImportError:
+    import json
+
 from test_utils.testmaker.serializers import REQUEST_UNIQUE_STRING, RESPONSE_UNIQUE_STRING
 
 class Serializer(base.Serializer):


### PR DESCRIPTION
At Django 1.7 `django.utils.simplejson` was removed in favor of the `json` standard library.

https://docs.djangoproject.com/en/1.8/internals/deprecation/