### PR TITLE
Fix ADMIN_FOR in 1.8

### DIFF
--- a/test_utils/management/commands/crawlurls.py
+++ b/test_utils/management/commands/crawlurls.py
@@ -72,7 +72,7 @@ class Command(BaseCommand):
         else:
             start_url = args[0] if args else '/'
 
-        if settings.ADMIN_FOR:
+        if getattr(settings, 'ADMIN_FOR', None):
             settings_modules = [__import__(m, {}, {}, ['']) for m in settings.ADMIN_FOR]
         else:
             settings_modules = [settings]


### PR DESCRIPTION
`ADMIN_FOR` was removed in 1.8. this prevents the AttributeError.