### PR TITLE
Unpack namespace and name

### DIFF
--- a/test_utils/management/commands/crawlurls.py
+++ b/test_utils/management/commands/crawlurls.py
@@ -88,7 +88,7 @@ class Command(BaseCommand):
                 continue
 
             view_functions = extract_views_from_urlpatterns(urlconf.urlpatterns)
-            for (func, regex) in view_functions:
+            for (func, regex, namespace, name) in view_functions:
                 #Get function name and add it to the hash of URLConf urls
                 func_name = hasattr(func, '__name__') and func.__name__ or repr(func)
                 conf_urls[regex] = ['func.__module__', func_name]


### PR DESCRIPTION
Django's admindocs.extract_view_from_urlpatterns now unpacks namespace and name
https://github.com/django/django/blob/16a842b3795ca78a5918538ab6b9f1afbd718f72/django/contrib/admindocs/views.py#L383